### PR TITLE
Implement AMQPDecimal handling in headers via ValueProcessor

### DIFF
--- a/src/AmqpCompat/Driver/Amqplib/Processor/ValueProcessor.php
+++ b/src/AmqpCompat/Driver/Amqplib/Processor/ValueProcessor.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Asmblah\PhpAmqpCompat\Driver\Amqplib\Processor;
 
+use AMQPDecimal;
 use AMQPTimestamp;
 use Asmblah\PhpAmqpCompat\Driver\Common\Processor\ValueProcessorInterface;
 use DateTime;
 use DateTimeInterface;
+use PhpAmqpLib\Wire\AMQPDecimal as AmqplibDecimal;
 
 /**
  * Class ValueProcessor.
@@ -40,7 +42,10 @@ class ValueProcessor implements ValueProcessorInterface
             return $value;
         }
 
-        // TODO: Handle AMQPDecimal.
+        if ($value instanceof AMQPDecimal) {
+            // Note that php-amqplib's significand and exponent parameters are reversed.
+            return new AmqplibDecimal($value->getSignificand(), $value->getExponent());
+        }
 
         if ($value instanceof AMQPTimestamp) {
             return DateTime::createFromFormat('U', $value->getTimestamp());
@@ -62,7 +67,10 @@ class ValueProcessor implements ValueProcessorInterface
             return $value;
         }
 
-        // TODO: Handle AMQPDecimal.
+        if ($value instanceof AmqplibDecimal) {
+            // Note that php-amqplib's significand and exponent parameters are reversed.
+            return new AMQPDecimal($value->getE(), $value->getN());
+        }
 
         if ($value instanceof DateTimeInterface) {
             return new AMQPTimestamp($value->getTimestamp());

--- a/tests/Functional/Reference/ReferenceImplementationTest.php
+++ b/tests/Functional/Reference/ReferenceImplementationTest.php
@@ -52,7 +52,6 @@ class ReferenceImplementationTest extends AbstractTestCase
         'amqpexchange_publish_mandatory.phpt',
         'amqpexchange_publish_mandatory_consume.phpt',
         'amqpexchange_publish_mandatory_multiple_channels_pitfal.phpt',
-        'amqpexchange_publish_with_decimal_header.phpt', // TODO: Needs ValueProcessor for AMQPDecimal support.
         'amqpexchange_publish_with_null.phpt',
         'amqpexchange_publish_with_properties_ignore_num_header.phpt',
         'amqpexchange_publish_with_properties_ignore_unsupported_header_values.phpt',
@@ -90,6 +89,7 @@ class ReferenceImplementationTest extends AbstractTestCase
         'amqpenvelope_construct.php' => [1],
         'amqpenvelope_get_accessors.php' => [5],
         'amqpenvelope_var_dump.php' => [5, 5],
+        'amqpexchange_publish_with_decimal_header.php' => [7, 5],
         'amqpexchange_setArgument.php' => [3, 1, 2, 1, 4, 1, 2, 1, 4, 1, 2, 1],
         'amqpexchange_set_flags.php' => [3, 1, 2, 1],
         'amqpexchange_var_dump.php' => [3, 1, 2, 1, 3, 1, 2, 1],

--- a/tests/Functional/Reference/Util/ClassEmulator/AmqpDecimalEmulator.php
+++ b/tests/Functional/Reference/Util/ClassEmulator/AmqpDecimalEmulator.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * PHP AMQP-Compat - php-amqp/ext-amqp compatibility.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/php-amqp-compat/
+ *
+ * Released under the MIT license.
+ * https://github.com/asmblah/php-amqp-compat/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator;
+
+use AMQPDecimal;
+use LogicException;
+
+/**
+ * Class AmqpDecimalEmulator.
+ *
+ * Dumps instances of AMQPDecimal exactly as expected by the reference implementation tests.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class AmqpDecimalEmulator implements ClassEmulatorInterface
+{
+    /**
+     * Dumps the given AMQPDecimal instance.
+     */
+    public function dump(
+        AMQPDecimal $decimal,
+        int $depth,
+        int $objectId,
+        DelegatingClassEmulatorInterface $emulator
+    ): string {
+        return <<<OUT
+object(AMQPDecimal)#$objectId (2) {
+  ["exponent":"AMQPDecimal":private]=>
+  {$emulator->dump($decimal->getExponent(), $depth + 1)}
+  ["significand":"AMQPDecimal":private]=>
+  {$emulator->dump($decimal->getSignificand(), $depth + 1)}
+}
+OUT;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getClassName(): string
+    {
+        return AMQPDecimal::class;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDumper(): callable
+    {
+        return $this->dump(...);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMethodFetcher(): callable
+    {
+        return fn () => throw new LogicException(__METHOD__ . '(): Not implemented');
+    }
+}

--- a/tests/Functional/Reference/Util/CodeShifts.php
+++ b/tests/Functional/Reference/Util/CodeShifts.php
@@ -13,9 +13,11 @@ declare(strict_types=1);
 
 namespace Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util;
 
+use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\ReferenceImplementationTest;
 use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\AmqpBasicPropertiesEmulator;
 use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\AmqpChannelEmulator;
 use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\AmqpConnectionEmulator;
+use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\AmqpDecimalEmulator;
 use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\AmqpEnvelopeEmulator;
 use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\AmqpExchangeEmulator;
 use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\AmqpQueueEmulator;
@@ -72,12 +74,16 @@ class CodeShifts
             ])
         );
 
-        $classEmulator = new DelegatingClassEmulator(self::$contextResolver);
+        $classEmulator = new DelegatingClassEmulator(
+            self::$contextResolver,
+            ReferenceImplementationTest::VAR_DUMP_OBJECT_IDS
+        );
         self::$classEmulator = $classEmulator;
 
         $classEmulator->registerClassEmulator(new AmqpBasicPropertiesEmulator());
         $classEmulator->registerClassEmulator(new AmqpChannelEmulator());
         $classEmulator->registerClassEmulator(new AmqpConnectionEmulator());
+        $classEmulator->registerClassEmulator(new AmqpDecimalEmulator());
         $classEmulator->registerClassEmulator(new AmqpEnvelopeEmulator());
         $classEmulator->registerClassEmulator(new AmqpExchangeEmulator());
         $classEmulator->registerClassEmulator(new AmqpQueueEmulator());

--- a/tests/Unit/AmqpCompat/Driver/Amqplib/Processor/ValueProcessorTest.php
+++ b/tests/Unit/AmqpCompat/Driver/Amqplib/Processor/ValueProcessorTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Asmblah\PhpAmqpCompat\Tests\Unit\AmqpCompat\Driver\Amqplib\Processor;
 
+use AMQPDecimal;
 use AMQPTimestamp;
 use Asmblah\PhpAmqpCompat\Driver\Amqplib\Processor\ValueProcessor;
 use Asmblah\PhpAmqpCompat\Tests\AbstractTestCase;
 use DateTime;
+use PhpAmqpLib\Wire\AMQPDecimal as AmqplibDecimal;
 
 /**
  * Class ValueProcessorTest.
@@ -32,12 +34,37 @@ class ValueProcessorTest extends AbstractTestCase
         $this->processor = new ValueProcessor();
     }
 
+    public function testProcessValueForDriverConvertsAmqpDecimalToAmqplibDecimal(): void
+    {
+        $amqplibDecimal = $this->processor->processValueForDriver(new AMQPDecimal(3, 2));
+
+        static::assertInstanceOf(AmqplibDecimal::class, $amqplibDecimal);
+        static::assertSame(2, $amqplibDecimal->getN());
+        static::assertSame(3, $amqplibDecimal->getE());
+    }
+
     public function testProcessValueForDriverConvertsAmqpTimestampToDateTime(): void
     {
         $dateTime = $this->processor->processValueForDriver(new AMQPTimestamp(12345678));
 
         static::assertInstanceOf(DateTime::class, $dateTime);
         static::assertSame(12345678, $dateTime->getTimestamp());
+    }
+
+    public function testProcessValueForDriverConvertsAmqpDecimalNestedArrayValueToAmqplibDecimal(): void
+    {
+        $result = $this->processor->processValueForDriver([
+            'my' => [
+                'stuff' => [
+                    'my-decimal' => new AMQPDecimal(3, 2),
+                ],
+            ],
+        ]);
+
+        $amqplibDecimal = $result['my']['stuff']['my-decimal'];
+        static::assertInstanceOf(AmqplibDecimal::class, $amqplibDecimal);
+        static::assertSame(2, $amqplibDecimal->getN());
+        static::assertSame(3, $amqplibDecimal->getE());
     }
 
     public function testProcessValueForDriverConvertsAmqpTimestampNestedArrayValueToDateTime(): void
@@ -55,12 +82,37 @@ class ValueProcessorTest extends AbstractTestCase
         static::assertSame(12345678, $dateTime->getTimestamp());
     }
 
+    public function testProcessValueFromDriverConvertsAmqplibDecimalToAmqpDecimal(): void
+    {
+        $amqpDecimal = $this->processor->processValueFromDriver(new AmqplibDecimal(2, 3));
+
+        static::assertInstanceOf(AMQPDecimal::class, $amqpDecimal);
+        static::assertSame(2, $amqpDecimal->getSignificand());
+        static::assertSame(3, $amqpDecimal->getExponent());
+    }
+
     public function testProcessValueFromDriverConvertsDateTimeToAmqpTimestamp(): void
     {
         $amqpTimestamp = $this->processor->processValueFromDriver(DateTime::createFromFormat('U', '12345678'));
 
         static::assertInstanceOf(AMQPTimestamp::class, $amqpTimestamp);
         static::assertSame('12345678', $amqpTimestamp->getTimestamp());
+    }
+
+    public function testProcessValueFromDriverConvertsAmqplibDecimalNestedArrayValueToAmqpDecimal(): void
+    {
+        $result = $this->processor->processValueFromDriver([
+            'my' => [
+                'stuff' => [
+                    'my-decimal' => new AmqplibDecimal(2, 3),
+                ],
+            ],
+        ]);
+
+        $amqpDecimal = $result['my']['stuff']['my-decimal'];
+        static::assertInstanceOf(AMQPDecimal::class, $amqpDecimal);
+        static::assertSame(2, $amqpDecimal->getSignificand());
+        static::assertSame(3, $amqpDecimal->getExponent());
     }
 
     public function testProcessValueFromDriverConvertsDateTimeNestedArrayValueToAmqpTimestamp(): void

--- a/tests/Unit/Tests/Functional/Reference/Util/ClassEmulator/AmqpDecimalEmulatorTest.php
+++ b/tests/Unit/Tests/Functional/Reference/Util/ClassEmulator/AmqpDecimalEmulatorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * PHP AMQP-Compat - php-amqp/ext-amqp compatibility.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/php-amqp-compat/
+ *
+ * Released under the MIT license.
+ * https://github.com/asmblah/php-amqp-compat/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Asmblah\PhpAmqpCompat\Tests\Unit\Tests\Functional\Reference\Util\ClassEmulator;
+
+use AMQPDecimal;
+use Asmblah\PhpAmqpCompat\Tests\AbstractTestCase;
+use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\AmqpDecimalEmulator;
+use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\DelegatingClassEmulatorInterface;
+use Mockery\MockInterface;
+
+/**
+ * Class AmqpDecimalEmulatorTest.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class AmqpDecimalEmulatorTest extends AbstractTestCase
+{
+    private MockInterface&DelegatingClassEmulatorInterface $delegatingEmulator;
+    private AmqpDecimalEmulator $emulator;
+
+    public function setUp(): void
+    {
+        $this->delegatingEmulator = mock(DelegatingClassEmulatorInterface::class);
+
+        $this->delegatingEmulator->allows('dump')
+            ->andReturnUsing(function (mixed $value, int $depth) {
+                return '[dump depth=' . $depth . ']' . var_export($value, true) . '[/dump]';
+            })
+            ->byDefault();
+
+        $this->emulator = new AmqpDecimalEmulator();
+    }
+
+    public function testDumpDumpsCorrectlyWithDepthOfZero(): void
+    {
+        $amqpDecimal = new AMQPDecimal(3, 2);
+        $expectedOutput = <<<EOS
+object(AMQPDecimal)#123 (2) {
+  ["exponent":"AMQPDecimal":private]=>
+  [dump depth=1]3[/dump]
+  ["significand":"AMQPDecimal":private]=>
+  [dump depth=1]2[/dump]
+}
+EOS;
+
+        static::assertSame(
+            $expectedOutput,
+            $this->emulator->dump($amqpDecimal, 0, 123, $this->delegatingEmulator)
+        );
+    }
+
+    public function testDumpDumpsCorrectlyWithDepthGreaterThanZero(): void
+    {
+        $amqpDecimal = new AMQPDecimal(3, 2);
+        $expectedOutput = <<<EOS
+object(AMQPDecimal)#567 (2) {
+  ["exponent":"AMQPDecimal":private]=>
+  [dump depth=5]3[/dump]
+  ["significand":"AMQPDecimal":private]=>
+  [dump depth=5]2[/dump]
+}
+EOS;
+
+        static::assertSame(
+            $expectedOutput,
+            $this->emulator->dump($amqpDecimal, 4, 567, $this->delegatingEmulator)
+        );
+    }
+
+    public function testGetClassNameReturnsCorrectClass(): void
+    {
+        static::assertSame(AMQPDecimal::class, $this->emulator->getClassName());
+    }
+}

--- a/tests/Unit/Tests/Functional/Reference/Util/ClassEmulator/DelegatingClassEmulatorTest.php
+++ b/tests/Unit/Tests/Functional/Reference/Util/ClassEmulator/DelegatingClassEmulatorTest.php
@@ -1,0 +1,247 @@
+<?php
+
+/*
+ * PHP AMQP-Compat - php-amqp/ext-amqp compatibility.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/php-amqp-compat/
+ *
+ * Released under the MIT license.
+ * https://github.com/asmblah/php-amqp-compat/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Asmblah\PhpAmqpCompat\Tests\Unit\Tests\Functional\Reference\Util\ClassEmulator;
+
+use Asmblah\PhpAmqpCompat\Tests\AbstractTestCase;
+use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\ClassEmulatorInterface;
+use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ClassEmulator\DelegatingClassEmulator;
+use Asmblah\PhpAmqpCompat\Tests\Functional\Reference\Util\ContextResolver;
+use Generator;
+use LogicException;
+use Mockery\MockInterface;
+use stdClass;
+
+/**
+ * Class DelegatingClassEmulatorTest.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class DelegatingClassEmulatorTest extends AbstractTestCase
+{
+    private MockInterface&ContextResolver $contextResolver;
+    private DelegatingClassEmulator $emulator;
+
+    public function setUp(): void
+    {
+        $this->contextResolver = mock(ContextResolver::class);
+        $this->contextResolver->allows('getContext')
+            ->andReturn(['file' => 'my_first_module.php'])
+            ->byDefault();
+
+        $this->emulator = new DelegatingClassEmulator($this->contextResolver, [
+            'my_first_module.php' => [9998, 9994],
+        ]);
+        $this->emulator->setNativeGetClassMethods(
+            static fn ($objectOrClassName) => get_class_methods($objectOrClassName)
+        );
+        $this->emulator->setNativeVarDump(
+            function ($value) {
+                // A simplified var_dump just for testing. We cannot rely on native var_dump(...)
+                // because it may be overloaded by XDebug.
+                print '[dump]' . var_export($value, true) . '[/dump]';
+            }
+        );
+    }
+
+    /**
+     * @dataProvider simpleValueProvider
+     */
+    public function testDumpCanDumpSimpleValues(mixed $value, string $expectedOutput): void
+    {
+        static::assertSame($expectedOutput, $this->emulator->dump($value, 0));
+    }
+
+    public static function simpleValueProvider(): Generator
+    {
+        yield 'boolean true' => [true, '[dump]true[/dump]'];
+        yield 'boolean false' => [false, '[dump]false[/dump]'];
+        yield 'float' => [456.78, '[dump]456.78[/dump]'];
+        yield 'integer' => [1234, '[dump]1234[/dump]'];
+        yield 'null' => [null, '[dump]NULL[/dump]'];
+        yield 'string' => ['my string', "[dump]'my string'[/dump]"];
+    }
+
+    public function testDumpCanDumpArraysContainingSimpleValuesAndNestedArrays(): void
+    {
+        $expectedOutput = <<<EOS
+array(2) {
+  ["one"]=>
+  [dump]'first'[/dump]
+  ["two"]=>
+  array(2) {
+    [0]=>
+    [dump]'second'[/dump]
+    [1]=>
+    [dump]'third'[/dump]
+  }
+}
+EOS;
+
+        static::assertSame(
+            $expectedOutput,
+            $this->emulator->dump(
+                [
+                    'one' => 'first',
+                    'two' => ['second', 'third'],
+                ],
+                0
+            )
+        );
+    }
+
+    public function testDumpCanDumpAnInstanceOfANonEmulatedClass(): void
+    {
+        $object = new stdClass;
+        $object->prop1 = 21;
+        $object->prop2 = 101;
+        $expectedOutput = <<<EOS
+[dump](object) array(
+   'prop1' => 21,
+   'prop2' => 101,
+)[/dump]
+EOS;
+
+        static::assertSame(
+            $expectedOutput,
+            $this->emulator->dump($object, 0)
+        );
+    }
+
+    public function testDumpCanDumpAnInstanceOfAnEmulatedClass(): void
+    {
+        $object = new class {
+            public int $prop1 = 21;
+            public string $prop2 = 'my value';
+        };
+        $this->emulator->registerClassEmulator(new class (get_class($object)) implements ClassEmulatorInterface {
+            public function __construct(private readonly string $className)
+            {
+            }
+
+            public function getClassName(): string
+            {
+                return $this->className;
+            }
+
+            public function getDumper(): callable
+            {
+                return static fn (object $object, int $depth, int $objectId) =>
+                    '[object id=' . $objectId . "]\nprop1=" . $object->prop1 .
+                    "\nprop2=" . $object->prop2 . "\n[/object]";
+            }
+
+            public function getMethodFetcher(): callable
+            {
+                return static fn () => throw new LogicException('Not implemented');
+            }
+        });
+
+        $firstExpectedOutput = <<<EOS
+[object id=9998]
+prop1=21
+prop2=my value
+[/object]
+EOS;
+        // At depth > 0, we need to indent.
+        $secondExpectedOutput = <<<EOS
+[object id=9994]
+  prop1=21
+  prop2=my value
+  [/object]
+EOS;
+
+        static::assertSame(
+            $firstExpectedOutput,
+            $this->emulator->dump($object, 0)
+        );
+        static::assertSame(
+            $secondExpectedOutput,
+            $this->emulator->dump($object, 1)
+        );
+    }
+
+    public function testGetClassMethodsReturnsTheClassMethodsViaNativeFunctionWhenClassIsNotEmulated(): void
+    {
+        $className = get_class(new class {
+            public function getOne(): int
+            {
+                return 1;
+            }
+
+            public function getTwo(): int
+            {
+                return 2;
+            }
+        });
+
+        static::assertEquals(
+            ['getOne', 'getTwo'],
+            $this->emulator->getClassMethods($className)
+        );
+    }
+
+    public function testGetClassMethodsReturnsTheClassMethodsViaEmulatorWhenEmulated(): void
+    {
+        $object = new class {
+            public function getOne(): int
+            {
+                return 1;
+            }
+
+            public function getTwo(): int
+            {
+                return 2;
+            }
+        };
+        $className = get_class($object);
+        $this->emulator->registerClassEmulator(new class ($className) implements ClassEmulatorInterface {
+            public function __construct(private readonly string $className)
+            {
+            }
+
+            public function getClassName(): string
+            {
+                return $this->className;
+            }
+
+            public function getDumper(): callable
+            {
+                return static fn () => throw new LogicException('Not implemented');
+            }
+
+            public function getMethodFetcher(): callable
+            {
+                return static fn () => ['myFirstMethodFromEmulator', 'mySecondMethodFromEmulator'];
+            }
+        });
+
+        static::assertEquals(
+            ['myFirstMethodFromEmulator', 'mySecondMethodFromEmulator'],
+            $this->emulator->getClassMethods($className)
+        );
+    }
+
+    public function testGetPropertyValueFetchesThePropertyViaReflectionToIgnoreVisibility(): void
+    {
+        $object = new class {
+            public int $myPublicProp = 21;
+            /*
+             * @phpstan-ignore-next-line Ignore the "unused" private property, we read it with reflection.
+             */
+            private string $myPrivateProp = 'my value';
+        };
+
+        static::assertSame('my value', $this->emulator->getPropertyValue($object, 'myPrivateProp'));
+    }
+}


### PR DESCRIPTION
The `AMQPDecimal` class itself was handled, but it was not yet handled by `ValueProcessor`, which needs to translate between instances of this and php-amqplib's own `PhpAmqpLib\Wire\AMQPDecimal` class.
