### PR TITLE
Fix bug with lingering SIGALRMs set with `pcntl_alarm(...)` when long-running FastCGI worker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require-dev": {
         "asmblah/php-code-shift": "^0.1.0",
+        "hollodotme/fast-cgi-client": "^3.1",
         "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-mockery": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "88a4b39af497af73c090a30389eb6df8",
+    "content-hash": "51d955bdbc408b9a21335b6182bf85df",
     "packages": [
         {
             "name": "paragonie/constant_time_encoding",
@@ -459,6 +459,56 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
             },
             "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "hollodotme/fast-cgi-client",
+            "version": "v3.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hollodotme/fast-cgi-client.git",
+                "reference": "062182d4eda73c161cc2839783acc83096ec0f37"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hollodotme/fast-cgi-client/zipball/062182d4eda73c161cc2839783acc83096ec0f37",
+                "reference": "062182d4eda73c161cc2839783acc83096ec0f37",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "hollodotme\\FastCGI\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Holger Woltersdorf",
+                    "email": "hw@hollo.me"
+                }
+            ],
+            "description": "A PHP fast CGI client to send requests (a)synchronously to PHP-FPM.",
+            "keywords": [
+                "Socket",
+                "async",
+                "fastcgi",
+                "php-fpm"
+            ],
+            "support": {
+                "issues": "https://github.com/hollodotme/fast-cgi-client/issues",
+                "source": "https://github.com/hollodotme/fast-cgi-client/tree/v3.1.7"
+            },
+            "time": "2021-12-07T10:10:20+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/src/AmqpCompat/Heartbeat/PcntlHeartbeatSender.php
+++ b/src/AmqpCompat/Heartbeat/PcntlHeartbeatSender.php
@@ -75,6 +75,15 @@ class PcntlHeartbeatSender implements HeartbeatSenderInterface
         );
 
         pcntl_alarm($this->interval);
+
+        /*
+         * Ensure that for FastCGI requests, we do not leave any lingering SIGALRM timers set,
+         * as those will cause the process to exit unexpectedly with code 14
+         * during or before a subsequent request handled by this same FastCGI worker process.
+         */
+        register_shutdown_function(static function () {
+            pcntl_alarm(0);
+        });
     }
 
     /**

--- a/tests/Functional/AmqpCompat/Heartbeat/PcntlHeartbeatSender/PhpCgiBehaviourTest.php
+++ b/tests/Functional/AmqpCompat/Heartbeat/PcntlHeartbeatSender/PhpCgiBehaviourTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * PHP AMQP-Compat - php-amqp/ext-amqp compatibility.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/asmblah/php-amqp-compat/
+ *
+ * Released under the MIT license.
+ * https://github.com/asmblah/php-amqp-compat/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Asmblah\PhpAmqpCompat\Tests\Functional\AmqpCompat\Heartbeat\PcntlHeartbeatSender;
+
+use Asmblah\PhpAmqpCompat\Tests\AbstractTestCase;
+use hollodotme\FastCGI\Client;
+use hollodotme\FastCGI\Exceptions\ConnectException;
+use hollodotme\FastCGI\Requests\GetRequest;
+use hollodotme\FastCGI\Requests\PostRequest;
+use hollodotme\FastCGI\SocketConnections\NetworkSocket;
+
+/**
+ * Class PhpCgiBehaviourTest.
+ *
+ * Checks the behaviour of PcntlHeartbeatSender with php-cgi as the host process.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class PhpCgiBehaviourTest extends AbstractTestCase
+{
+    private const SERVER_HOST = '127.0.0.1';
+    private const SERVER_PORT = 9877;
+
+    private string $baseDir;
+    private Client $fastCgiClient;
+    private NetworkSocket $fastCgiConnection;
+    /** @var array<int, resource> */
+    private array $pipes = [];
+    /**
+     * @var resource
+     */
+    private $process;
+    private string $wwwDir;
+
+    public function setUp(): void
+    {
+        $this->baseDir = dirname(__DIR__, 5);
+        $this->wwwDir = $this->baseDir . '/tests/Functional/Fixtures/PhpCgi/www';
+
+        // Start long-running php-cgi process.
+        $descriptorSpec = array(
+            0 => array('pipe', 'r'), // Stdin.
+            1 => array('pipe', 'w'), // Stdout.
+            2 => array('pipe', 'w'), // Stderr.
+        );
+
+        // Spawn a long-running php-cgi process for handling FastCGI requests.
+        $process = proc_open(
+            sprintf(
+                'PHP_FCGI_CHILDREN=0 PHP_FCGI_MAX_REQUESTS=1000 php-cgi -d open_basedir=%s -b %s:%s',
+                $this->baseDir,
+                self::SERVER_HOST,
+                self::SERVER_PORT
+            ),
+            $descriptorSpec,
+            $this->pipes
+        );
+
+        if ($process === false) {
+            $this->fail('Failed to start php-cgi process.');
+        }
+
+        $this->process = $process;
+
+        $this->fastCgiClient = new Client();
+        $this->fastCgiConnection = new NetworkSocket(self::SERVER_HOST, self::SERVER_PORT);
+
+        // Wait for php-cgi to be ready to receive FastCGI requests.
+        for (;;) {
+            try {
+                $response = $this->fastCgiClient->sendRequest(
+                    $this->fastCgiConnection,
+                    new GetRequest('/', '')
+                );
+            } catch (ConnectException $exception) {
+                if (!str_contains($exception->getMessage(), 'Unable to connect to FastCGI application')) {
+                    throw $exception;
+                }
+
+                $response = null;
+            }
+
+            if ($response && $response->getHeaderLine('Status') === '404 Not Found') {
+                break;
+            }
+
+            usleep(100000);
+        }
+    }
+
+    public function tearDown(): void
+    {
+        fclose($this->pipes[0]);
+        fclose($this->pipes[1]);
+        fclose($this->pipes[2]);
+
+        $running = proc_get_status($this->process)['running'];
+
+        if (!$running) {
+            $exitCode = proc_close($this->process);
+
+            if ($exitCode !== -1) {
+                $this->fail('php-cgi process had stopped unexpectedly, exit code was ' . $exitCode);
+            }
+        }
+
+        proc_terminate($this->process, SIGTERM);
+        usleep(100 * 1000);
+        proc_terminate($this->process, SIGKILL);
+        proc_close($this->process);
+    }
+
+    public function testSubsequentRequestsDoNotReceiveLingeringSigalrms(): void
+    {
+        // Send first request, which will set SIGALRM to be triggered
+        // for the php-cgi process while it waits to process the next request.
+        $response1 = $this->fastCgiClient->sendRequest(
+            $this->fastCgiConnection,
+            new PostRequest(
+                $this->wwwDir . '/maybe_install_heartbeat_sender.php',
+                'heartbeat_interval=2'
+            )
+        );
+
+        /*
+         * Sleep for slightly longer than the interval given for SIGALRM to ensure it is triggered.
+         * If it has been left pending, then this will cause the php-cgi process to unexpectedly exit
+         * with an exit code of SIGALRM (14).
+         */
+        sleep(3);
+
+        $status = proc_get_status($this->process);
+
+        static::assertFalse(
+            $status['signaled'],
+            'php-cgi process was terminated with signal ' . $status['termsig']
+        );
+
+        $response2 = $this->fastCgiClient->sendRequest(
+            $this->fastCgiConnection,
+            new PostRequest(
+                $this->wwwDir . '/maybe_install_heartbeat_sender.php',
+                ''
+            )
+        );
+
+        static::assertSame('Installed heartbeat sender with 2 second interval' . PHP_EOL, $response1->getBody());
+        static::assertSame('Did not install heartbeat sender' . PHP_EOL, $response2->getBody());
+    }
+}

--- a/tests/Functional/Fixtures/PhpCgi/www/maybe_install_heartbeat_sender.php
+++ b/tests/Functional/Fixtures/PhpCgi/www/maybe_install_heartbeat_sender.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Asmblah\PhpAmqpCompat\Bridge\Connection\AmqpConnectionBridgeInterface;
+use Asmblah\PhpAmqpCompat\Heartbeat\PcntlHeartbeatSender;
+use Asmblah\PhpAmqpCompat\Misc\Clock;
+
+require_once dirname(__DIR__, 5) . '/vendor/autoload.php';
+
+$heartbeatInterval = $_POST['heartbeat_interval'] ?? null;
+
+if ($heartbeatInterval !== null) {
+    $pcntlHeartbeatSender = new PcntlHeartbeatSender(new Clock());
+
+    $pcntlHeartbeatSender->register(mock(AmqpConnectionBridgeInterface::class, [
+        'getHeartbeatInterval' => $heartbeatInterval,
+    ]));
+
+    print 'Installed heartbeat sender with ' . $heartbeatInterval . ' second interval' . PHP_EOL;
+} else {
+    print 'Did not install heartbeat sender' . PHP_EOL;
+}


### PR DESCRIPTION
Ensure that for FastCGI requests, we do not leave any lingering `SIGALRM` timers set with `pcntl_alarm(...)`,
as those will cause the process to exit unexpectedly with code 14 during or before a subsequent request handled by the same FastCGI worker process.
