### PR TITLE
Relax restriction on configuration being set once integration is set or fetched

### DIFF
--- a/src/AmqpCompat/AmqpManager.php
+++ b/src/AmqpCompat/AmqpManager.php
@@ -26,7 +26,6 @@ use Asmblah\PhpAmqpCompat\Integration\AmqpIntegration;
 use Asmblah\PhpAmqpCompat\Integration\AmqpIntegrationInterface;
 use Asmblah\PhpAmqpCompat\Misc\Clock;
 use Asmblah\PhpAmqpCompat\Misc\Ini;
-use LogicException;
 
 /**
  * Class AmqpManager.
@@ -86,6 +85,7 @@ class AmqpManager
     public static function setAmqpIntegration(?AmqpIntegrationInterface $amqpIntegration): void
     {
         self::$amqpIntegration = $amqpIntegration;
+        self::$configuration = $amqpIntegration?->getConfiguration();
     }
 
     /**
@@ -95,12 +95,10 @@ class AmqpManager
      */
     public static function setConfiguration(?ConfigurationInterface $configuration): void
     {
-        if (self::$amqpIntegration !== null) {
-            // Raise an error, because the configuration would not be used by the current AmqpIntegration
-            // which would be inconsistent.
-            throw new LogicException('Cannot set configuration while an AmqpIntegration has already been set');
-        }
-
         self::$configuration = $configuration;
+
+        // Clear any current integration, otherwise the configuration may not be used by it
+        // which would be inconsistent.
+        self::$amqpIntegration = null;
     }
 }

--- a/src/AmqpCompat/Integration/AmqpIntegration.php
+++ b/src/AmqpCompat/Integration/AmqpIntegration.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Asmblah\PhpAmqpCompat\Integration;
 
+use Asmblah\PhpAmqpCompat\Bridge\Channel\Consumer;
 use Asmblah\PhpAmqpCompat\Bridge\Channel\EnvelopeTransformerInterface;
 use Asmblah\PhpAmqpCompat\Bridge\Connection\AmqpConnectionBridge;
 use Asmblah\PhpAmqpCompat\Bridge\Connection\AmqpConnectionBridgeInterface;
@@ -46,7 +47,7 @@ class AmqpIntegration implements AmqpIntegrationInterface
     public function __construct(
         private readonly ConnectorInterface $connector,
         private readonly HeartbeatSenderInterface $heartbeatSender,
-        ConfigurationInterface $configuration,
+        private readonly ConfigurationInterface $configuration,
         private readonly DefaultConnectionConfigInterface $defaultConnectionConfig,
         private readonly EnvelopeTransformerInterface $envelopeTransformer,
         private readonly MessageTransformerInterface $messageTransformer
@@ -162,6 +163,14 @@ class AmqpIntegration implements AmqpIntegrationInterface
             $connectionName,
             $deprecatedTimeoutCredentialUsage
         );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getConfiguration(): ConfigurationInterface
+    {
+        return $this->configuration;
     }
 
     /**

--- a/src/AmqpCompat/Integration/AmqpIntegrationInterface.php
+++ b/src/AmqpCompat/Integration/AmqpIntegrationInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Asmblah\PhpAmqpCompat\Integration;
 
 use Asmblah\PhpAmqpCompat\Bridge\Connection\AmqpConnectionBridgeInterface;
+use Asmblah\PhpAmqpCompat\Configuration\ConfigurationInterface;
 use Asmblah\PhpAmqpCompat\Connection\Config\ConnectionConfigInterface;
 use Asmblah\PhpAmqpCompat\Error\ErrorReporterInterface;
 use Asmblah\PhpAmqpCompat\Logger\LoggerInterface;
@@ -41,6 +42,11 @@ interface AmqpIntegrationInterface
      * @param array<mixed> $credentials
      */
     public function createConnectionConfig(array $credentials): ConnectionConfigInterface;
+
+    /**
+     * Fetches the configuration for this library.
+     */
+    public function getConfiguration(): ConfigurationInterface;
 
     /**
      * Fetches an ErrorReporter to use when raising warnings/notices etc.

--- a/tests/Integrated/Amqp/PublishThenConsumeTest.php
+++ b/tests/Integrated/Amqp/PublishThenConsumeTest.php
@@ -22,6 +22,7 @@ use Asmblah\PhpAmqpCompat\AmqpManager;
 use Asmblah\PhpAmqpCompat\Bridge\AmqpBridge;
 use Asmblah\PhpAmqpCompat\Bridge\Channel\EnvelopeTransformer;
 use Asmblah\PhpAmqpCompat\Bridge\Connection\AmqpConnectionBridge;
+use Asmblah\PhpAmqpCompat\Configuration\ConfigurationInterface;
 use Asmblah\PhpAmqpCompat\Connection\Config\ConnectionConfigInterface;
 use Asmblah\PhpAmqpCompat\Connection\Config\TimeoutDeprecationUsageEnum;
 use Asmblah\PhpAmqpCompat\Driver\Amqplib\Exception\ExceptionHandler;
@@ -79,6 +80,7 @@ class PublishThenConsumeTest extends AbstractTestCase
         $this->errorReporter = mock(ErrorReporterInterface::class);
         $this->amqpIntegration = mock(AmqpIntegrationInterface::class, [
             'createConnectionConfig' => $this->connectionConfig,
+            'getConfiguration' => mock(ConfigurationInterface::class),
             'getErrorReporter' => $this->errorReporter,
             'getLogger' => $this->logger,
         ]);

--- a/tests/Unit/Amqp/AMQPConnectionTest.php
+++ b/tests/Unit/Amqp/AMQPConnectionTest.php
@@ -18,6 +18,7 @@ use AMQPConnectionException;
 use Asmblah\PhpAmqpCompat\AmqpManager;
 use Asmblah\PhpAmqpCompat\Bridge\AmqpBridge;
 use Asmblah\PhpAmqpCompat\Bridge\Connection\AmqpConnectionBridgeInterface;
+use Asmblah\PhpAmqpCompat\Configuration\ConfigurationInterface;
 use Asmblah\PhpAmqpCompat\Connection\Config\ConnectionConfigInterface;
 use Asmblah\PhpAmqpCompat\Connection\Config\TimeoutDeprecationUsageEnum;
 use Asmblah\PhpAmqpCompat\Error\ErrorReporterInterface;
@@ -84,6 +85,7 @@ class AMQPConnectionTest extends AbstractTestCase
         $this->amqpIntegration = mock(AmqpIntegrationInterface::class, [
             'connect' => $this->connectionBridge,
             'createConnectionConfig' => $this->connectionConfig,
+            'getConfiguration' => mock(ConfigurationInterface::class),
             'getErrorReporter' => $this->errorReporter,
             'getLogger' => $this->logger,
         ]);

--- a/tests/Unit/AmqpCompat/AmqpIntegrationTest.php
+++ b/tests/Unit/AmqpCompat/AmqpIntegrationTest.php
@@ -211,6 +211,11 @@ class AmqpIntegrationTest extends AbstractTestCase
         static::assertSame(456.7, $config->getReadTimeout());
     }
 
+    public function testGetConfigurationReturnsTheConfiguration(): void
+    {
+        static::assertSame($this->configuration, $this->amqpIntegration->getConfiguration());
+    }
+
     public function testGetErrorReporterReturnsTheErrorReporter(): void
     {
         static::assertSame($this->errorReporter, $this->amqpIntegration->getErrorReporter());


### PR DESCRIPTION
Even when the AMQP integration has already been set (or created implicitly), the configuration can now still be set, which will clear the current integration for consistency.