### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "asmblah/php-code-shift": "^0.1.0",
-        "mockery/mockery": "^1.6",
+        "mockery/mockery": "1.6.11",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-mockery": "^1.1",
         "phpunit/phpunit": "^10.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a97db5a1fd7260b07073d517aeae9844",
+    "content-hash": "99977e380d35934d6dc5f089e46eb96f",
     "packages": [
         {
             "name": "nytris/nytris",
@@ -50,24 +50,24 @@
         },
         {
             "name": "paragonie/constant_time_encoding",
-            "version": "v2.6.3",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/constant_time_encoding.git",
-                "reference": "58c3f47f650c94ec05a151692652a868995d2938"
+                "reference": "df1e7fde177501eee2037dd159cf04f5f301a512"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/58c3f47f650c94ec05a151692652a868995d2938",
-                "reference": "58c3f47f650c94ec05a151692652a868995d2938",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/df1e7fde177501eee2037dd159cf04f5f301a512",
+                "reference": "df1e7fde177501eee2037dd159cf04f5f301a512",
                 "shasum": ""
             },
             "require": {
-                "php": "^7|^8"
+                "php": "^8"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6|^7|^8|^9",
-                "vimeo/psalm": "^1|^2|^3|^4"
+                "phpunit/phpunit": "^9",
+                "vimeo/psalm": "^4|^5"
             },
             "type": "library",
             "autoload": {
@@ -113,7 +113,7 @@
                 "issues": "https://github.com/paragonie/constant_time_encoding/issues",
                 "source": "https://github.com/paragonie/constant_time_encoding"
             },
-            "time": "2022-06-14T06:56:20+00:00"
+            "time": "2024-05-08T12:36:18+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -248,20 +248,20 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.37",
+            "version": "3.0.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "cfa2013d0f68c062055180dd4328cc8b9d1f30b8"
+                "reference": "56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/cfa2013d0f68c062055180dd4328cc8b9d1f30b8",
-                "reference": "cfa2013d0f68c062055180dd4328cc8b9d1f30b8",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6",
+                "reference": "56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6",
                 "shasum": ""
             },
             "require": {
-                "paragonie/constant_time_encoding": "^1|^2",
+                "paragonie/constant_time_encoding": "^1|^2|^3",
                 "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
                 "php": ">=5.6.1"
             },
@@ -338,7 +338,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.37"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.46"
             },
             "funding": [
                 {
@@ -354,20 +354,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-03T02:14:58+00:00"
+            "time": "2025-06-26T16:29:55+00:00"
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
@@ -402,35 +402,35 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "asmblah/php-code-shift",
-            "version": "v0.1.8",
+            "version": "v0.1.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/asmblah/php-code-shift.git",
-                "reference": "e9ea2ffbfec99b721ed3fd5a5d83faace1219021"
+                "reference": "5e8b68031f1feaf6c35a7d866437dc0c312e6b69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/asmblah/php-code-shift/zipball/e9ea2ffbfec99b721ed3fd5a5d83faace1219021",
-                "reference": "e9ea2ffbfec99b721ed3fd5a5d83faace1219021",
+                "url": "https://api.github.com/repos/asmblah/php-code-shift/zipball/5e8b68031f1feaf6c35a7d866437dc0c312e6b69",
+                "reference": "5e8b68031f1feaf6c35a7d866437dc0c312e6b69",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.16",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "nytris/nytris": "^0.1",
                 "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
                 "symfony/filesystem": "^5.4"
             },
             "require-dev": {
-                "mockery/mockery": "^1.6",
+                "mockery/mockery": "1.6.11",
                 "phpstan/phpstan": "^1.10",
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpunit/phpunit": "^10.2"
@@ -450,26 +450,26 @@
             ],
             "support": {
                 "issues": "https://github.com/asmblah/php-code-shift/issues",
-                "source": "https://github.com/asmblah/php-code-shift/tree/v0.1.8"
+                "source": "https://github.com/asmblah/php-code-shift/tree/v0.1.20"
             },
-            "time": "2024-04-30T17:06:05+00:00"
+            "time": "2024-11-13T00:33:19+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.1",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3|^7.0|^8.0"
+                "php": "^7.4|^8.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -477,8 +477,8 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
-                "phpunit/php-file-iterator": "^1.4 || ^2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -501,9 +501,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
-            "time": "2020-07-09T08:09:16+00:00"
+            "time": "2025-04-30T06:54:44+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -590,16 +590,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/faed855a7b5f4d4637717c2b3863e277116beb36",
+                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36",
                 "shasum": ""
             },
             "require": {
@@ -607,11 +607,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -637,7 +638,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.3"
             },
             "funding": [
                 {
@@ -645,29 +646,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2025-07-05T12:25:42+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.1",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b"
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4e1b88d21c69391150ace211e9eaf05810858d0b",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -675,7 +678,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -699,9 +702,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
             },
-            "time": "2024-03-17T08:10:35+00:00"
+            "time": "2025-05-31T08:24:38+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -823,16 +826,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.67",
+            "version": "1.12.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493"
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/16ddbe776f10da6a95ebd25de7c1dbed397dc493",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
                 "shasum": ""
             },
             "require": {
@@ -877,32 +880,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-16T07:22:02+00:00"
+            "time": "2025-07-17T17:15:39+00:00"
         },
         {
             "name": "phpstan/phpstan-mockery",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-mockery.git",
-                "reference": "88ae85931768efd3aaf3cce4cb9cb54c4d157d03"
+                "reference": "98cac6e256b4ee60fdeb26a7dd81bb271b454e80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/88ae85931768efd3aaf3cce4cb9cb54c4d157d03",
-                "reference": "88ae85931768efd3aaf3cce4cb9cb54c4d157d03",
+                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/98cac6e256b4ee60fdeb26a7dd81bb271b454e80",
+                "reference": "98cac6e256b4ee60fdeb26a7dd81bb271b454e80",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.10"
+                "phpstan/phpstan": "^1.12"
             },
             "require-dev": {
-                "mockery/mockery": "^1.2.4",
+                "mockery/mockery": "^1.6.11",
                 "nikic/php-parser": "^4.13.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan-strict-rules": "^1.6",
                 "phpunit/phpunit": "^9.5"
             },
             "type": "phpstan-extension",
@@ -925,38 +928,38 @@
             "description": "PHPStan Mockery extension",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-mockery/issues",
-                "source": "https://github.com/phpstan/phpstan-mockery/tree/1.1.2"
+                "source": "https://github.com/phpstan/phpstan-mockery/tree/1.1.3"
             },
-            "time": "2024-01-10T13:50:05+00:00"
+            "time": "2024-09-11T15:47:29+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.14",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
-                "reference": "e3f51450ebffe8e0efdf7346ae966a656f7d5e5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^3.0",
-                "sebastian/complexity": "^3.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/lines-of-code": "^2.0",
-                "sebastian/version": "^4.0",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.1"
@@ -968,7 +971,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -997,7 +1000,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.14"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
             },
             "funding": [
                 {
@@ -1005,7 +1008,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-12T15:33:41+00:00"
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1252,16 +1255,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.20",
+            "version": "10.5.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3"
+                "reference": "6e0a2bc39f6fae7617989d690d76c48e6d2eb541"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/547d314dc24ec1e177720d45c6263fb226cc2ae3",
-                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6e0a2bc39f6fae7617989d690d76c48e6d2eb541",
+                "reference": "6e0a2bc39f6fae7617989d690d76c48e6d2eb541",
                 "shasum": ""
             },
             "require": {
@@ -1271,26 +1274,26 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.13.3",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.5",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-invoker": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "phpunit/php-timer": "^6.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/code-unit": "^2.0",
-                "sebastian/comparator": "^5.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.1",
-                "sebastian/global-state": "^6.0.1",
-                "sebastian/object-enumerator": "^5.0",
-                "sebastian/recursion-context": "^5.0",
-                "sebastian/type": "^4.0",
-                "sebastian/version": "^4.0"
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.3",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.2",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.0",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -1333,7 +1336,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.48"
             },
             "funding": [
                 {
@@ -1345,11 +1348,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-24T06:32:35+00:00"
+            "time": "2025-07-11T04:07:17+00:00"
         },
         {
             "name": "react/event-loop",
@@ -1422,6 +1433,79 @@
                 }
             ],
             "time": "2023-11-13T13:48:05+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "8a164643313c71354582dc850b42b33fa12a4b63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/8a164643313c71354582dc850b42b33fa12a4b63",
+                "reference": "8a164643313c71354582dc850b42b33fa12a4b63",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.10.39 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-05-24T10:39:05+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1593,16 +1677,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.1",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2db5010a484d53ebf536087a70b4a5423c102372"
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2db5010a484d53ebf536087a70b4a5423c102372",
-                "reference": "2db5010a484d53ebf536087a70b4a5423c102372",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
                 "shasum": ""
             },
             "require": {
@@ -1613,7 +1697,7 @@
                 "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.3"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
@@ -1658,7 +1742,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.3"
             },
             "funding": [
                 {
@@ -1666,7 +1750,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-14T13:18:12+00:00"
+            "time": "2024-10-18T14:56:07+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -2341,23 +2425,25 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.39",
+            "version": "v5.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e6edd875d5d39b03de51f3c3951148cfa79a4d12"
+                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e6edd875d5d39b03de51f3c3951148cfa79a4d12",
-                "reference": "e6edd875d5d39b03de51f3c3951148cfa79a4d12",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/57c8294ed37d4a055b77057827c67f9558c95c54",
+                "reference": "57c8294ed37d4a055b77057827c67f9558c95c54",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8",
-                "symfony/polyfill-php80": "^1.16",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "require-dev": {
                 "symfony/process": "^5.4|^6.4"
             },
             "type": "library",
@@ -2386,7 +2472,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.39"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.45"
             },
             "funding": [
                 {
@@ -2402,24 +2488,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T08:26:06+00:00"
+            "time": "2024-10-22T13:05:35+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.29.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
-                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-ctype": "*"
@@ -2430,8 +2516,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2465,7 +2551,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2481,24 +2567,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.29.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
-                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "ext-iconv": "*",
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-mbstring": "*"
@@ -2509,8 +2596,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2545,7 +2632,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2561,30 +2648,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.29.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2625,7 +2712,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2641,96 +2728,39 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v6.4.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "cdb1c81c145fd5aa9b0038bab694035020943381"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/cdb1c81c145fd5aa9b0038bab694035020943381",
-                "reference": "cdb1c81c145fd5aa9b0038bab694035020943381",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.7"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-04-18T09:22:46+00:00"
+            "time": "2025-01-02T08:10:11+00:00"
         },
         {
             "name": "tasque/event-loop",
-            "version": "v0.1.2",
+            "version": "v0.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nytris/tasque-event-loop.git",
-                "reference": "842fb1945fcd213763d4d6fd4bbb07dd929efafc"
+                "reference": "0b5c95434e08b64b94bdf8790dbea0cad74a9c49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nytris/tasque-event-loop/zipball/842fb1945fcd213763d4d6fd4bbb07dd929efafc",
-                "reference": "842fb1945fcd213763d4d6fd4bbb07dd929efafc",
+                "url": "https://api.github.com/repos/nytris/tasque-event-loop/zipball/0b5c95434e08b64b94bdf8790dbea0cad74a9c49",
+                "reference": "0b5c95434e08b64b94bdf8790dbea0cad74a9c49",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "react/event-loop": "^1.4",
+                "react/event-loop": "^1.5",
+                "react/promise": "^3.2 || ^2.11",
                 "tasque/tasque": "^0.1"
             },
             "require-dev": {
-                "mockery/mockery": "^1.6",
+                "mockery/mockery": "1.6.11",
                 "phpstan/phpstan": "^1.10",
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpunit/phpunit": "^10.2"
             },
             "type": "project",
             "autoload": {
+                "files": [
+                    "src/bootstrap.php"
+                ],
                 "psr-4": {
                     "Tasque\\EventLoop\\": "src/"
                 }
@@ -2741,22 +2771,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nytris/tasque-event-loop/issues",
-                "source": "https://github.com/nytris/tasque-event-loop/tree/v0.1.2"
+                "source": "https://github.com/nytris/tasque-event-loop/tree/v0.1.5"
             },
-            "time": "2023-11-08T18:08:53+00:00"
+            "time": "2024-08-21T02:33:37+00:00"
         },
         {
             "name": "tasque/tasque",
-            "version": "v0.1.4",
+            "version": "v0.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nytris/tasque.git",
-                "reference": "64b5c4ec784f960d765662504d98041f5699bdc3"
+                "reference": "283bc9b9f1cd46b565754f1cc1cdf1bc9637cc4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nytris/tasque/zipball/64b5c4ec784f960d765662504d98041f5699bdc3",
-                "reference": "64b5c4ec784f960d765662504d98041f5699bdc3",
+                "url": "https://api.github.com/repos/nytris/tasque/zipball/283bc9b9f1cd46b565754f1cc1cdf1bc9637cc4c",
+                "reference": "283bc9b9f1cd46b565754f1cc1cdf1bc9637cc4c",
                 "shasum": ""
             },
             "require": {
@@ -2765,7 +2795,7 @@
                 "php": ">=8.1"
             },
             "require-dev": {
-                "mockery/mockery": "^1.6",
+                "mockery/mockery": "1.6.11",
                 "phpstan/phpstan": "^1.10",
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpunit/phpunit": "^10.2",
@@ -2786,9 +2816,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nytris/tasque/issues",
-                "source": "https://github.com/nytris/tasque/tree/v0.1.4"
+                "source": "https://github.com/nytris/tasque/tree/v0.1.8"
             },
-            "time": "2024-02-06T07:15:27+00:00"
+            "time": "2024-08-09T17:15:28+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2843,14 +2873,14 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=8.1",
         "ext-sockets": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1"
     },

--- a/phpstan-baseline.neon.dist
+++ b/phpstan-baseline.neon.dist
@@ -1,0 +1,156 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Result of method AMQPQueue\\:\\:reject\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Functional/Amqp/Amqp/AMQPQueueTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$timeout of method AMQPConnection\\:\\:setReadTimeout\\(\\) expects int, float given\\.$#"
+			count: 1
+			path: tests/Functional/Amqp/ConnectionTimeoutTuningTest.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between int\\<1, max\\> and 0 will always evaluate to false\\.$#"
+			count: 1
+			path: tests/Functional/Reference/Util/bootstrap.php
+
+		-
+			message: "#^Result of method AMQPChannel\\:\\:basicRecover\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPChannelTest.php
+
+		-
+			message: "#^Result of method AMQPChannel\\:\\:commitTransaction\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPChannelTest.php
+
+		-
+			message: "#^Result of method AMQPChannel\\:\\:qos\\(\\) \\(void\\) is used\\.$#"
+			count: 2
+			path: tests/Unit/Amqp/AMQPChannelTest.php
+
+		-
+			message: "#^Result of method AMQPChannel\\:\\:rollbackTransaction\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPChannelTest.php
+
+		-
+			message: "#^Result of method AMQPChannel\\:\\:setPrefetchCount\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPChannelTest.php
+
+		-
+			message: "#^Result of method AMQPChannel\\:\\:setPrefetchSize\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPChannelTest.php
+
+		-
+			message: "#^Result of method AMQPChannel\\:\\:startTransaction\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPChannelTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$timeout of method AMQPConnection\\:\\:setReadTimeout\\(\\) expects int, float given\\.$#"
+			count: 3
+			path: tests/Unit/Amqp/AMQPConnectionTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$timeout of method AMQPConnection\\:\\:setTimeout\\(\\) expects int, float given\\.$#"
+			count: 2
+			path: tests/Unit/Amqp/AMQPConnectionTest.php
+
+		-
+			message: "#^Result of method AMQPConnection\\:\\:connect\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPConnectionTest.php
+
+		-
+			message: "#^Result of method AMQPConnection\\:\\:disconnect\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPConnectionTest.php
+
+		-
+			message: "#^Result of method AMQPConnection\\:\\:setReadTimeout\\(\\) \\(void\\) is used\\.$#"
+			count: 3
+			path: tests/Unit/Amqp/AMQPConnectionTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$exchangeName of method AMQPExchange\\:\\:delete\\(\\) expects string, null given\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPExchangeTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$value of method AMQPExchange\\:\\:setArgument\\(\\) expects bool\\|float\\|int\\|string\\|null, stdClass given\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPExchangeTest.php
+
+		-
+			message: "#^Result of method AMQPExchange\\:\\:bind\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPExchangeTest.php
+
+		-
+			message: "#^Result of method AMQPExchange\\:\\:unbind\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPExchangeTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$value of method AMQPQueue\\:\\:setArgument\\(\\) expects AMQPDecimal\\|AMQPTimestamp\\|AMQPValue\\|array\\|bool\\|float\\|int\\|string\\|null, stdClass given\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPQueueTest.php
+
+		-
+			message: "#^Result of method AMQPQueue\\:\\:ack\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPQueueTest.php
+
+		-
+			message: "#^Result of method AMQPQueue\\:\\:nack\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPQueueTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$timestamp of class AMQPTimestamp constructor expects float\\|int, true given\\.$#"
+			count: 1
+			path: tests/Unit/Amqp/AMQPTimestampTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$exceptionClass of method Asmblah\\\\PhpAmqpCompat\\\\Driver\\\\Amqplib\\\\Exception\\\\ExceptionHandler\\:\\:handleException\\(\\) expects class\\-string\\<AMQPException\\>, string given\\.$#"
+			count: 1
+			path: tests/Unit/AmqpCompat/Driver/Amqplib/Exception/ExceptionHandlerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$attributes of method Asmblah\\\\PhpAmqpCompat\\\\Driver\\\\Amqplib\\\\Transformer\\\\MessageTransformer\\:\\:transformEnvelope\\(\\) expects array\\{app_id\\?\\: string, content_encoding\\?\\: string, content_type\\?\\: string, delivery_mode\\?\\: string, expiration\\?\\: string, headers\\?\\: array, message_id\\?\\: string, priority\\?\\: string, \\.\\.\\.\\}, array\\{app_id\\: 1234\\} given\\.$#"
+			count: 1
+			path: tests/Unit/AmqpCompat/Driver/Amqplib/Transformer/MessageTransformerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$attributes of method Asmblah\\\\PhpAmqpCompat\\\\Driver\\\\Amqplib\\\\Transformer\\\\MessageTransformer\\:\\:transformEnvelope\\(\\) expects array\\{app_id\\?\\: string, content_encoding\\?\\: string, content_type\\?\\: string, delivery_mode\\?\\: string, expiration\\?\\: string, headers\\?\\: array, message_id\\?\\: string, priority\\?\\: string, \\.\\.\\.\\}, array\\{content_encoding\\: 1234\\} given\\.$#"
+			count: 1
+			path: tests/Unit/AmqpCompat/Driver/Amqplib/Transformer/MessageTransformerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$attributes of method Asmblah\\\\PhpAmqpCompat\\\\Driver\\\\Amqplib\\\\Transformer\\\\MessageTransformer\\:\\:transformEnvelope\\(\\) expects array\\{app_id\\?\\: string, content_encoding\\?\\: string, content_type\\?\\: string, delivery_mode\\?\\: string, expiration\\?\\: string, headers\\?\\: array, message_id\\?\\: string, priority\\?\\: string, \\.\\.\\.\\}, array\\{content_type\\: 123\\} given\\.$#"
+			count: 1
+			path: tests/Unit/AmqpCompat/Driver/Amqplib/Transformer/MessageTransformerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$attributes of method Asmblah\\\\PhpAmqpCompat\\\\Driver\\\\Amqplib\\\\Transformer\\\\MessageTransformer\\:\\:transformEnvelope\\(\\) expects array\\{app_id\\?\\: string, content_encoding\\?\\: string, content_type\\?\\: string, delivery_mode\\?\\: string, expiration\\?\\: string, headers\\?\\: array, message_id\\?\\: string, priority\\?\\: string, \\.\\.\\.\\}, array\\{message_id\\: 543\\} given\\.$#"
+			count: 1
+			path: tests/Unit/AmqpCompat/Driver/Amqplib/Transformer/MessageTransformerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$attributes of method Asmblah\\\\PhpAmqpCompat\\\\Driver\\\\Amqplib\\\\Transformer\\\\MessageTransformer\\:\\:transformEnvelope\\(\\) expects array\\{app_id\\?\\: string, content_encoding\\?\\: string, content_type\\?\\: string, delivery_mode\\?\\: string, expiration\\?\\: string, headers\\?\\: array, message_id\\?\\: string, priority\\?\\: string, \\.\\.\\.\\}, array\\{reply_to\\: 543\\} given\\.$#"
+			count: 1
+			path: tests/Unit/AmqpCompat/Driver/Amqplib/Transformer/MessageTransformerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$attributes of method Asmblah\\\\PhpAmqpCompat\\\\Driver\\\\Amqplib\\\\Transformer\\\\MessageTransformer\\:\\:transformEnvelope\\(\\) expects array\\{app_id\\?\\: string, content_encoding\\?\\: string, content_type\\?\\: string, delivery_mode\\?\\: string, expiration\\?\\: string, headers\\?\\: array, message_id\\?\\: string, priority\\?\\: string, \\.\\.\\.\\}, array\\{type\\: 654\\} given\\.$#"
+			count: 1
+			path: tests/Unit/AmqpCompat/Driver/Amqplib/Transformer/MessageTransformerTest.php
+
+		-
+			message: "#^Property class@anonymous/tests/Unit/Tests/Functional/Reference/Util/ClassEmulator/DelegatingClassEmulatorTest\\.php\\:237\\:\\:\\$myPrivateProp is never read, only written\\.$#"
+			count: 1
+			path: tests/Unit/Tests/Functional/Reference/Util/ClassEmulator/DelegatingClassEmulatorTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 includes:
     - vendor/phpstan/phpstan-mockery/extension.neon
+    - phpstan-baseline.neon.dist
 
 parameters:
     level: 6

--- a/tests/Functional/Amqp/ConnectionTimeoutTuningTest.php
+++ b/tests/Functional/Amqp/ConnectionTimeoutTuningTest.php
@@ -58,13 +58,6 @@ class ConnectionTimeoutTuningTest extends AbstractFunctionalTestCase
         $amqpConnection = new AMQPConnection(['read_timeout' => 10]);
         $amqpConnection->connect();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $timeout of method AMQPConnection::setReadTimeout() expects int, float given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $amqpConnection->setReadTimeout(18.5);
 
         static::assertTrue($amqpConnection->isConnected());

--- a/tests/Functional/Reference/ReferenceImplementationTest.php
+++ b/tests/Functional/Reference/ReferenceImplementationTest.php
@@ -130,16 +130,17 @@ class ReferenceImplementationTest extends AbstractFunctionalTestCase
         exec($command, $stdoutLines, $exitCode);
         $stdout = implode("\n", $stdoutLines);
 
-        if (preg_match('/^Tests skipped   :    1 \(100\.0%\)/m', $stdout)) {
+        if (preg_match('/^Tests skipped\s*:\s*1\s*\(100\.0%\)/m', $stdout)) {
             // run-tests.php reported a skipped test.
             $this->markTestSkipped('Test skipped, stdout was: ' . $stdout);
         }
 
-        if (!preg_match('/^Tests passed    :    1 \(100\.0%\)/m', $stdout)) {
-            // run-tests.php reported a failed test.
-            $this->fail('Test failed or warned, stdout was: ' . $stdout);
-        }
-
+        // Ensure run-tests.php did not report a failed test.
+        static::assertMatchesRegularExpression(
+            '/^Tests passed\s*:\s*1\s*\(100\.0%\)/m',
+            $stdout,
+            'Test failed or warned, stdout was: ' . $stdout
+        );
         static::assertSame(0, $exitCode, 'Expected exit code 0, stdout was: ' . $stdout);
     }
 

--- a/tests/Functional/Reference/Util/CodeShifts.php
+++ b/tests/Functional/Reference/Util/CodeShifts.php
@@ -69,8 +69,8 @@ class CodeShifts
                 }
             ),
             new MultipleFilter([
-                new FileFilter('*.php'),
-                new FileFilter('*.php.inc'),
+                new FileFilter('**/*.php'),
+                new FileFilter('**/*.php.inc'),
             ])
         );
 
@@ -104,8 +104,8 @@ class CodeShifts
                 }
             ),
             new MultipleFilter([
-                new FileFilter('*.php'),
-                new FileFilter('*.php.inc'),
+                new FileFilter('**/*.php'),
+                new FileFilter('**/*.php.inc'),
             ])
         );
 
@@ -123,8 +123,8 @@ class CodeShifts
                 }
             ),
             new MultipleFilter([
-                new FileFilter('*.php'),
-                new FileFilter('*.php.inc'),
+                new FileFilter('**/*.php'),
+                new FileFilter('**/*.php.inc'),
             ])
         );
     }

--- a/tests/Functional/Reference/Util/bootstrap.php
+++ b/tests/Functional/Reference/Util/bootstrap.php
@@ -45,7 +45,7 @@ Nytris::boot($bootConfig);
 if (isset($argv)) {
     // Force the actual test script to be loaded via file:// stream wrapper,
     // so that PHP Code Shift can transpile it.
-    if (count($argv) === 0) { // @phpstan-ignore-line
+    if (count($argv) === 0) {
         throw new RuntimeException('Missing test script');
     }
 

--- a/tests/Unit/Amqp/AMQPChannelTest.php
+++ b/tests/Unit/Amqp/AMQPChannelTest.php
@@ -440,7 +440,6 @@ class AMQPChannelTest extends AbstractTestCase
             ])
             ->once();
 
-        // @phpstan-ignore-next-line
         $this->amqpChannel->qos($prefetchSize, $prefetchCount, $global);
     }
 
@@ -453,7 +452,6 @@ class AMQPChannelTest extends AbstractTestCase
             ->basic_qos($prefetchSize, $prefetchCount, $global)
             ->once();
 
-        // @phpstan-ignore-next-line
         static::assertTrue($this->amqpChannel->qos($prefetchSize, $prefetchCount, $global));
     }
 
@@ -481,7 +479,6 @@ class AMQPChannelTest extends AbstractTestCase
             'message(my text)'
         );
 
-        // @phpstan-ignore-next-line
         $this->amqpChannel->qos($prefetchSize, $prefetchCount, $global);
     }
 

--- a/tests/Unit/Amqp/AMQPConnectionTest.php
+++ b/tests/Unit/Amqp/AMQPConnectionTest.php
@@ -525,13 +525,6 @@ class AMQPConnectionTest extends AbstractTestCase
             ->setReadTimeout(18.05)
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $timeout of method AMQPConnection::setReadTimeout() expects int, float given."
-         *
-         * @phpstan-ignore-next-line
-         */
         static::assertTrue($this->amqpConnection->setReadTimeout(18.05));
     }
 
@@ -542,13 +535,6 @@ class AMQPConnectionTest extends AbstractTestCase
             ->andThrow(new TransportConfigurationFailedException());
         $this->amqpConnection->connect();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $timeout of method AMQPConnection::setReadTimeout() expects int, float given."
-         *
-         * @phpstan-ignore-next-line
-         */
         static::assertFalse($this->amqpConnection->setReadTimeout(18.05));
     }
 
@@ -558,13 +544,6 @@ class AMQPConnectionTest extends AbstractTestCase
             ->setReadTimeout(18.05)
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $timeout of method AMQPConnection::setReadTimeout() expects int, float given."
-         *
-         * @phpstan-ignore-next-line
-         */
         static::assertTrue($this->amqpConnection->setReadTimeout(18.05));
     }
 
@@ -574,13 +553,6 @@ class AMQPConnectionTest extends AbstractTestCase
             ->setReadTimeout(12.34)
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $timeout of method AMQPConnection::setTimeout() expects int, float given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpConnection->setTimeout(12.34);
     }
 
@@ -596,13 +568,6 @@ class AMQPConnectionTest extends AbstractTestCase
             )
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $timeout of method AMQPConnection::setTimeout() expects int, float given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpConnection->setTimeout(12.34);
     }
 

--- a/tests/Unit/Amqp/AMQPExchangeTest.php
+++ b/tests/Unit/Amqp/AMQPExchangeTest.php
@@ -443,7 +443,7 @@ class AMQPExchangeTest extends AbstractTestCase
             ])
             ->once();
 
-        $this->amqpExchange->delete(null, $flags); // @phpstan-ignore-line
+        $this->amqpExchange->delete(null, $flags);
     }
 
     /**
@@ -728,13 +728,6 @@ class AMQPExchangeTest extends AbstractTestCase
         $this->expectException(AMQPExchangeException::class);
         $this->expectExceptionMessage('The value parameter must be of type NULL, int, double or string.');
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "Parameter #2 $value of method AMQPExchange::setArgument() expects int|string, stdClass given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpExchange->setArgument('my_key', new stdClass);
     }
 
@@ -752,13 +745,6 @@ class AMQPExchangeTest extends AbstractTestCase
     {
         $this->amqpExchange->setArguments(['first_key' => 21, 'second_key' => 'my value']);
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "Parameter #2 $value of method AMQPExchange::setArgument() expects int|string, null given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpExchange->setArgument('first_key', null);
 
         static::assertEquals(

--- a/tests/Unit/Amqp/AMQPQueueTest.php
+++ b/tests/Unit/Amqp/AMQPQueueTest.php
@@ -143,13 +143,6 @@ class AMQPQueueTest extends AbstractTestCase
             ])
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::ack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->ack(123);
     }
 
@@ -159,13 +152,6 @@ class AMQPQueueTest extends AbstractTestCase
             ->basic_ack(321, false)
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::ack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->ack(321);
     }
 
@@ -175,13 +161,6 @@ class AMQPQueueTest extends AbstractTestCase
             ->basic_ack(321, true)
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::ack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->ack(321, AMQP_MULTIPLE);
     }
 
@@ -198,25 +177,11 @@ class AMQPQueueTest extends AbstractTestCase
             'message(Bang!) isConsumption(no)'
         );
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::ack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->ack(123);
     }
 
     public function testAckReturnsTrue(): void
     {
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::ack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         static::assertTrue($this->amqpQueue->ack(321));
     }
 
@@ -230,13 +195,6 @@ class AMQPQueueTest extends AbstractTestCase
             ->debug('AMQPQueue::ack(): Message acknowledged')
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::ack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->ack(123);
     }
 
@@ -987,13 +945,6 @@ class AMQPQueueTest extends AbstractTestCase
             ])
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::nack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->nack(123);
     }
 
@@ -1003,13 +954,6 @@ class AMQPQueueTest extends AbstractTestCase
             ->basic_nack(321, false, false)
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::nack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->nack(321);
     }
 
@@ -1019,13 +963,6 @@ class AMQPQueueTest extends AbstractTestCase
             ->basic_nack(321, true, false)
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::nack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->nack(321, AMQP_MULTIPLE);
     }
 
@@ -1035,13 +972,6 @@ class AMQPQueueTest extends AbstractTestCase
             ->basic_nack(321, false, true)
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::nack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->nack(321, AMQP_REQUEUE);
     }
 
@@ -1058,25 +988,11 @@ class AMQPQueueTest extends AbstractTestCase
             'message(Bang!) isConsumption(no)'
         );
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::nack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->nack(123);
     }
 
     public function testNackReturnsTrue(): void
     {
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::nack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         static::assertTrue($this->amqpQueue->nack(321));
     }
 
@@ -1090,13 +1006,6 @@ class AMQPQueueTest extends AbstractTestCase
             ->debug('AMQPQueue::nack(): Message negatively acknowledged')
             ->once();
 
-        /*
-         * TODO: Fix whatever is causing PHPStan to wrongly raise a failure here:
-         *
-         * "phpstan: Parameter #1 $deliveryTag of method AMQPQueue::nack() expects string, int given."
-         *
-         * @phpstan-ignore-next-line
-         */
         $this->amqpQueue->nack(123);
     }
 

--- a/tests/Unit/Amqp/AMQPTimestampTest.php
+++ b/tests/Unit/Amqp/AMQPTimestampTest.php
@@ -67,11 +67,6 @@ class AMQPTimestampTest extends AbstractTestCase
             'AMQPTimestamp::__construct(): Argument #1 ($timestamp) must be of type float, boolean given'
         );
 
-        /*
-         * Ignore this type error as we are triggering it deliberately.
-         *
-         * @phpstan-ignore-next-line
-         */
         new AMQPTimestamp(true /* Boolean is invalid. */);
     }
 

--- a/tests/Unit/AmqpCompat/Driver/Amqplib/Exception/ExceptionHandlerTest.php
+++ b/tests/Unit/AmqpCompat/Driver/Amqplib/Exception/ExceptionHandlerTest.php
@@ -71,7 +71,7 @@ class ExceptionHandlerTest extends AbstractTestCase
 
         $this->handler->handleException(
             $exception,
-            RuntimeException::class, // @phpstan-ignore-line Due to intentional invalid class being given.
+            RuntimeException::class,
             'myMethod'
         );
     }

--- a/tests/Unit/AmqpCompat/Driver/Amqplib/Transformer/MessageTransformerTest.php
+++ b/tests/Unit/AmqpCompat/Driver/Amqplib/Transformer/MessageTransformerTest.php
@@ -96,9 +96,6 @@ class MessageTransformerTest extends AbstractTestCase
 
     public function testTransformEnvelopeCastsAppIdToStringWhenSpecified(): void
     {
-        /*
-         * @phpstan-ignore-next-line Ignore the deliberate type error.
-         */
         $amqplibMessage = $this->transformer->transformEnvelope('my message body', [
             'app_id' => 1234,
         ]);
@@ -108,9 +105,6 @@ class MessageTransformerTest extends AbstractTestCase
 
     public function testTransformEnvelopeCastsContentEncodingToStringWhenSpecified(): void
     {
-        /*
-         * @phpstan-ignore-next-line Ignore the deliberate type error.
-         */
         $amqplibMessage = $this->transformer->transformEnvelope('my message body', [
             'content_encoding' => 1234,
         ]);
@@ -138,9 +132,6 @@ class MessageTransformerTest extends AbstractTestCase
 
     public function testTransformEnvelopeCastsMessageIdToStringWhenSpecified(): void
     {
-        /*
-         * @phpstan-ignore-next-line Ignore the deliberate type error.
-         */
         $amqplibMessage = $this->transformer->transformEnvelope('my message body', [
             'message_id' => 543,
         ]);
@@ -159,9 +150,6 @@ class MessageTransformerTest extends AbstractTestCase
 
     public function testTransformEnvelopeCastsReplyToToStringWhenSpecified(): void
     {
-        /*
-         * @phpstan-ignore-next-line Ignore the deliberate type error.
-         */
         $amqplibMessage = $this->transformer->transformEnvelope('my message body', [
             'reply_to' => 543,
         ]);
@@ -180,9 +168,6 @@ class MessageTransformerTest extends AbstractTestCase
 
     public function testTransformEnvelopeCastsTypeToStringWhenSpecified(): void
     {
-        /*
-         * @phpstan-ignore-next-line Ignore the deliberate type error.
-         */
         $amqplibMessage = $this->transformer->transformEnvelope('my message body', [
             'type' => 654,
         ]);
@@ -199,9 +184,6 @@ class MessageTransformerTest extends AbstractTestCase
 
     public function testTransformEnvelopeCastsContentTypeToStringWhenSpecified(): void
     {
-        /*
-         * @phpstan-ignore-next-line Ignore the deliberate type error.
-         */
         $amqplibMessage = $this->transformer->transformEnvelope('my message body', [
             'content_type' => 123,
         ]);

--- a/tests/Unit/Tests/Functional/Reference/Util/ClassEmulator/DelegatingClassEmulatorTest.php
+++ b/tests/Unit/Tests/Functional/Reference/Util/ClassEmulator/DelegatingClassEmulatorTest.php
@@ -236,9 +236,6 @@ EOS;
     {
         $object = new class {
             public int $myPublicProp = 21;
-            /*
-             * @phpstan-ignore-next-line Ignore the "unused" private property, we read it with reflection.
-             */
             private string $myPrivateProp = 'my value';
         };
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 use Nytris\Boot\BootConfig;
 use Nytris\Boot\PlatformConfig;
 use Nytris\Nytris;
-use Tasque\Core\Scheduler\ContextSwitch\NTockStrategy;
+use Tasque\Core\Scheduler\ContextSwitch\TimeSliceStrategy;
 use Tasque\EventLoop\TasqueEventLoopPackage;
 use Tasque\TasquePackage;
 
@@ -24,7 +24,7 @@ Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
 Mockery::globalHelpers();
 
 $bootConfig = new BootConfig(new PlatformConfig(dirname(__DIR__) . '/var/nytris/'));
-$bootConfig->installPackage(new TasquePackage(new NTockStrategy(1)));
+$bootConfig->installPackage(new TasquePackage(new TimeSliceStrategy()));
 $bootConfig->installPackage(new TasqueEventLoopPackage());
 
 Nytris::boot($bootConfig);


### PR DESCRIPTION
- Updates dependencies, except for `mockery/mockery` with its known issue that breaks `phpstan/phpstan-mockery`.
- Moves PHPStan exclusions to a separate `phpstan-baseline.neon.dist` file.